### PR TITLE
Update packagegroup-webos-devel.bb

### DIFF
--- a/meta-webos/recipes-core/packagegroups/packagegroup-webos-devel.bb
+++ b/meta-webos/recipes-core/packagegroups/packagegroup-webos-devel.bb
@@ -25,5 +25,6 @@ RDEPENDS_${PN} = "\
     libpcap \
     nmon \
     sp-memusage \
+    wiringpi \
     ${VALGRIND} \
 "


### PR DESCRIPTION
main : add wiringpi library
to support gpio libarary with WebOS
Fix: #14
Signed-off-by author: JoonhoRyu <ruujoon93@gmail.com>

I will going to do more work for gpio daemo programs or service.