### PR TITLE
qemu: support graphic hw acceleration

### DIFF
--- a/meta-webos/conf/machine/include/qemuboot-x86.inc
+++ b/meta-webos/conf/machine/include/qemuboot-x86.inc
@@ -1,0 +1,16 @@
+# For runqemu
+IMAGE_CLASSES += "qemuboot"
+QB_SYSTEM_NAME_x86 = "qemu-system-i386"
+QB_CPU_x86 = "-cpu qemu32"
+QB_CPU_KVM_x86 = "-cpu kvm32"
+
+QB_SYSTEM_NAME_x86-64 = "qemu-system-x86_64"
+QB_CPU_x86-64 = "-cpu core2duo"
+QB_CPU_KVM_x86-64 = "-cpu kvm64"
+
+QB_AUDIO_DRV = "alsa"
+QB_AUDIO_OPT = "-soundhw ac97,es1370"
+QB_KERNEL_CMDLINE_APPEND = "vga=0 uvesafb.mode_option=1280x720-32 oprofile.timer=1 uvesafb.task_timeout=-1"
+# Add the 'virtio-rng-pci' device otherwise the guest may run out of entropy
+QB_OPT_APPEND = "-vga virtio -display sdl,gl=on -show-cursor -usb -usbdevice tablet -device virtio-rng-pci"
+QB_MEM = "-m 1024"

--- a/meta-webos/recipes-devtools/qemu/qemu_%.bbappend
+++ b/meta-webos/recipes-devtools/qemu/qemu_%.bbappend
@@ -5,7 +5,7 @@ EXTENDPRAUTO_append = "webos2"
 PACKAGECONFIG[sdl2] = "--with-sdlabi=2.0,--with-sdlabi=1.2,libsdl2"
 PACKAGECONFIG[virglrenderer] = "--enable-virglrenderer,--disable-virglrenderer,virglrenderer"
 
-PACKAGECONFIG_class-native = "fdt alsa sdl sdl2 virglrenderer"
+PACKAGECONFIG_class-native = "fdt alsa sdl sdl2 virglrenderer glx"
 PACKAGECONFIG_class-nativesdk = "fdt sdl sdl sdl2 virglrenderer"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"

--- a/meta-webos/recipes-graphics/libepoxy/libepoxy_%.bbappend
+++ b/meta-webos/recipes-graphics/libepoxy/libepoxy_%.bbappend
@@ -5,7 +5,7 @@ EXTENDPRAUTO_append = "webos1"
 REQUIRED_DISTRO_FEATURES_class-native = ""
 REQUIRED_DISTRO_FEATURES_class-nativesdk = ""
 
-PACKAGECONFIG_class-native = "egl"
+PACKAGECONFIG_class-native = "x11 egl"
 PACKAGECONFIG_class-nativesdk = "egl"
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
:Release Notes:
support "runqemu qemux86" to use hw acceleration options

:Detailed Notes:
Currently qemux86 generated from oe build fails launching with hw
acceleration options (e.g. -vga virtio -display sdl,gl=on)
on X11 WM linux host.
- To support acceleration options, the following should be required.
qemu should be compiled with "--enable-opengl".
- libepoxy should be compiled with "-enable-x11" as well as
"-enable-egl" (These options are not mutual exclusive.).

:Testing Performed:
Tested locally on Ubuntu 18.04.
$ runqemu qemux86 kvm slirp

:QA Notes:
None

:Issues Addressed:
None