### PR TITLE
bb files for gpio service.

### DIFF
--- a/meta-webos-raspberrypi/conf/machine/include/webos-rpi.inc
+++ b/meta-webos-raspberrypi/conf/machine/include/webos-rpi.inc
@@ -38,9 +38,10 @@ MACHINE_EXTRA_RRECOMMENDS_append_raspberrypi3 = " \
     kernel-module-uinput \
     kernel-module-uvcvideo \
     kernel-module-videodev \
+    kernel-module-xpad \
 "
 
-KERNEL_MODULE_AUTOLOAD_append = " uinput"
+KERNEL_MODULE_AUTOLOAD_append = " uinput xpad"
 
 # Disabling U-Boot until IP address conflict and ALSA issues resolved (PLAT-46515)
 # RPI_USE_U_BOOT = "1"

--- a/meta-webos-raspberrypi/recipes-core/packagegroups/packagegroup-webos-extended.bbappend
+++ b/meta-webos-raspberrypi/recipes-core/packagegroups/packagegroup-webos-extended.bbappend
@@ -19,6 +19,10 @@ MEDIA_raspberrypi3-64 = ""
 AISERVICE = " \
     com.webos.service.ai \
 "
+
+GPIOSERVICE = " \
+    com.webos.service.rpi.gpio \
+"
 # There is only rpi-32bit keyword detection library available.(https://github.com/Kitt-AI/snowboy/tree/master/lib)
 # It seems to be a library for arm-64bit(https://github.com/Kitt-AI/snowboy/tree/master/lib/aarch64-ubuntu1604),
 # but it has not been verified on webOS rpi64 which cannot boot yet.
@@ -28,4 +32,6 @@ RDEPENDS_${PN}_append_rpi = " \
     com.webos.service.audiooutput \
     ${MEDIA} \
     ${AISERVICE} \
+    wiringpi \
+    ${GPIOSERVICE} \
 "

--- a/meta-webos/recipes-webos/com.webos.service.rpi.gpio/com.webos.service.rpi.gpio.bb
+++ b/meta-webos/recipes-webos/com.webos.service.rpi.gpio/com.webos.service.rpi.gpio.bb
@@ -1,0 +1,20 @@
+SUMMARY = "GPIO service for WebOS RPI"
+AUTHOR = "Joonho Ryu <ruujoon93@gmail.com>"
+SECTION = "webos/extended-service"
+LICENSE = "Apache-2.0"
+
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+DEPENDS= "glib-2.0 json-c wiringpi pmloglib luna-service2"
+
+inherit webos_component
+inherit webos_cmake
+inherit webos_system_bus
+inherit webos_public_repo
+inherit webos_enhanced_submissions
+
+WEBOS_VERSION = "1.0.0-2_adec5b1e3c9062a4642daf0e9f37bdead7433a90"
+PR = "r0"
+
+SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
+S = "${WORKDIR}/git"

--- a/meta-webos/recipes-webos/com.webos.service.rpi.gpio/com.webos.service.rpi.gpio.bb
+++ b/meta-webos/recipes-webos/com.webos.service.rpi.gpio/com.webos.service.rpi.gpio.bb
@@ -13,7 +13,7 @@ inherit webos_system_bus
 inherit webos_public_repo
 inherit webos_enhanced_submissions
 
-WEBOS_VERSION = "1.0.0-2_adec5b1e3c9062a4642daf0e9f37bdead7433a90"
+WEBOS_VERSION = "1.0.0-3_7953fcc009c2a12eb9ae38fb7c2ad6bd735f86cb"
 PR = "r0"
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"


### PR DESCRIPTION
I made meta-webos/recipes-webos/com.webos.service.rpi.gpio/com.webos.service.rpi.gpio.bb to use gpio control service and modified packagegroup-webos-extended.bbappend for bitbake webos-image to build com.webos.service.rpi.gpio.

signed off by joonho ryu <ruujoon93@gmail.com>
